### PR TITLE
Use UUID implementation from Ruby Standard Library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ install:
  - "gem install contracts"
  - "gem install rspec"
  - "gem install webmock"
- - "gem install uuid"
  - "gem install coveralls"
 
 script: rspec

--- a/lib/snowplow-tracker/tracker.rb
+++ b/lib/snowplow-tracker/tracker.rb
@@ -15,7 +15,6 @@
 
 require 'contracts'
 require 'set'
-require 'uuid'
 
 module SnowplowTracker
 
@@ -81,7 +80,6 @@ module SnowplowTracker
       @config = {
         'encode_base64' => encode_base64
       }
-      @uuid = UUID.new
 
       self
     end
@@ -99,7 +97,7 @@ module SnowplowTracker
     # Generates a type-4 UUID to identify this event
     Contract nil => String
     def get_event_id()
-      @uuid.generate
+      SecureRandom.uuid
     end
 
     # Generates the timestamp (in milliseconds) to be attached to each event

--- a/snowplow-tracker.gemspec
+++ b/snowplow-tracker.gemspec
@@ -35,7 +35,6 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 1.9.3'
 
   s.add_runtime_dependency "contracts", "~> 0.7", "<= 0.11"
-  s.add_runtime_dependency "uuid", "~> 2.3.7"
   s.add_development_dependency "rspec", "~> 2.14.1"
   s.add_development_dependency "webmock", "~> 1.17.4"
 


### PR DESCRIPTION
UUID gem randomly fails when generating UUIDs with high frequency.
See: https://github.com/assaf/uuid/issues/28