### PR TITLE
Require securerandom in tracker

### DIFF
--- a/lib/snowplow-tracker/tracker.rb
+++ b/lib/snowplow-tracker/tracker.rb
@@ -14,6 +14,7 @@
 # License:: Apache License Version 2.0
 
 require 'contracts'
+require 'securerandom'
 require 'set'
 
 module SnowplowTracker


### PR DESCRIPTION
It fixes https://github.com/snowplow/snowplow-ruby-tracker/commit/d5c9ee15c5dec5c1242274ae7e1e812b59859ae5#commitcomment-13630395