### PR TITLE
Use keyword arguments for legibility

### DIFF
--- a/lib/snowplow-tracker/payload.rb
+++ b/lib/snowplow-tracker/payload.rb
@@ -36,25 +36,25 @@ module SnowplowTracker
       @context[name] = value if (value != '') && !value.nil?
     end
 
-    # Add each name-value pair in dict to @context
+    # Add each name-value pair in hash to @context
     #
     Contract Hash => Hash
-    def add_dict(dict)
-      dict.each { |key, value| add(key, value) }
+    def add_hash(hash)
+      hash.each { |key, value| add(key, value) }
     end
 
     # Stringify a JSON and add it to @context
     #
     Contract Maybe[Hash], Bool, String, String => Maybe[String]
-    def add_json(dict, encode_base64, type_when_encoded, type_when_not_encoded)
-      return if dict.nil?
+    def add_json(hash, encode_base64, type_when_encoded, type_when_not_encoded)
+      return if hash.nil?
 
-      dict_string = JSON.generate(dict)
+      hash_string = JSON.generate(hash)
 
       if encode_base64
-        add(type_when_encoded, Base64.strict_encode64(dict_string))
+        add(type_when_encoded, Base64.strict_encode64(hash_string))
       else
-        add(type_when_not_encoded, dict_string)
+        add(type_when_not_encoded, hash_string)
       end
     end
   end

--- a/lib/snowplow-tracker/subject.rb
+++ b/lib/snowplow-tracker/subject.rb
@@ -61,8 +61,8 @@ module SnowplowTracker
     # Set the screen resolution for a device
     # Part of the public API
     #
-    Contract Num, Num => Subject
-    def set_screen_resolution(width, height)
+    Contract KeywordArgs[width: Num, height: Num] => Subject
+    def set_screen_resolution(width:, height:)
       @standard_nv_pairs['res'] = "#{width}x#{height}"
       self
     end
@@ -70,8 +70,8 @@ module SnowplowTracker
     # Set the dimensions of the current viewport
     # Part of the public API
     #
-    Contract Num, Num => Subject
-    def set_viewport(width, height)
+    Contract KeywordArgs[width: Num, height: Num] => Subject
+    def set_viewport(width:, height:)
       @standard_nv_pairs['vp'] = "#{width}x#{height}"
       self
     end

--- a/snowplow-tracker.gemspec
+++ b/snowplow-tracker.gemspec
@@ -32,7 +32,11 @@ Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.required_ruby_version = '>= 2.1'
 
-  s.add_runtime_dependency "contracts", "~> 0.7", "< 0.17"
-  s.add_development_dependency "rspec", "~> 3.10"
-  s.add_development_dependency "webmock", "~> 3.14"
+  if RUBY_VERSION >= '3.0.0'
+    s.add_runtime_dependency 'contracts', '~> 0.17'
+  else
+    s.add_runtime_dependency 'contracts', '~> 0.7', '< 0.17'
+  end
+  s.add_development_dependency 'rspec', '~> 3.10'
+  s.add_development_dependency 'webmock', '~> 3.14'
 end

--- a/spec/unit/emitters_spec.rb
+++ b/spec/unit/emitters_spec.rb
@@ -30,7 +30,7 @@ describe SnowplowTracker::Emitter, 'configuration' do
   let(:default_opts) { { logger: NULL_LOGGER } }
 
   it 'should initialise correctly using default settings' do
-    e = SnowplowTracker::Emitter.new('d3rkrsqld9gmqf.cloudfront.net', default_opts)
+    e = SnowplowTracker::Emitter.new(endpoint: 'd3rkrsqld9gmqf.cloudfront.net', options: default_opts)
     expect(e.collector_uri).to eq('http://d3rkrsqld9gmqf.cloudfront.net/i')
     expect(e.buffer_size).to eq(1)
   end
@@ -38,14 +38,14 @@ describe SnowplowTracker::Emitter, 'configuration' do
   it 'should initialise correctly using custom settings' do
     on_success = ->(x) { x }
     on_failure = ->(_x, y) { y }
-    e = SnowplowTracker::Emitter.new('d3rkrsqld9gmqf.cloudfront.net', default_opts.merge(
-                                                                        protocol: 'https',
-                                                                        port: 80,
-                                                                        method: 'post',
-                                                                        buffer_size: 7,
-                                                                        on_success: on_success,
-                                                                        on_failure: on_failure
-                                                                      ))
+    e = SnowplowTracker::Emitter.new(endpoint: 'd3rkrsqld9gmqf.cloudfront.net', options: default_opts.merge(
+      protocol: 'https',
+      port: 80,
+      method: 'post',
+      buffer_size: 7,
+      on_success: on_success,
+      on_failure: on_failure
+    ))
     expect(e.collector_uri).to eq('https://d3rkrsqld9gmqf.cloudfront.net:80/com.snowplowanalytics.snowplow/tp2')
     expect(e.buffer_size).to eq(7)
     expect(e.on_success).to eq(on_success)
@@ -57,7 +57,7 @@ describe SnowplowTracker::Emitter, 'Sending requests' do
   let(:default_opts) { { logger: NULL_LOGGER } }
 
   it 'sends a payload' do
-    emitter = SnowplowTracker::Emitter.new('localhost', default_opts)
+    emitter = SnowplowTracker::Emitter.new(endpoint: 'localhost', options: default_opts)
     emitter.input('key' => 'value')
     param_hash = CGI.parse(emitter.get_last_querystring)
     expect(param_hash['key'][0]).to eq('value')
@@ -66,33 +66,33 @@ describe SnowplowTracker::Emitter, 'Sending requests' do
 
   it 'executes a callback on success' do
     callback_executed = false
-    emitter = SnowplowTracker::Emitter.new('localhost', default_opts.merge(
-                                                          on_success: ->(successes) {
-                                                            expect(successes).to eq(1)
-                                                            callback_executed = true
-                                                          }
-                                                        ))
+    emitter = SnowplowTracker::Emitter.new(endpoint: 'localhost', options: default_opts.merge(
+      on_success: ->(successes) {
+        expect(successes).to eq(1)
+        callback_executed = true
+      }
+    ))
     emitter.input('success' => 'good')
     expect(callback_executed).to eq(true)
   end
 
   it 'executes a callback on failure' do
     callback_executed = false
-    emitter = SnowplowTracker::Emitter.new('nonexistent', default_opts.merge(
-                                                            on_failure: ->(successes, failures) {
-                                                              expect(successes).to eq(0)
-                                                              expect(failures[0]['failure']).to eq('bad')
-                                                              callback_executed = true
-                                                            }
-                                                          ))
+    emitter = SnowplowTracker::Emitter.new(endpoint: 'nonexistent', options: default_opts.merge(
+      on_failure: ->(successes, failures) {
+        expect(successes).to eq(0)
+        expect(failures[0]['failure']).to eq('bad')
+        callback_executed = true
+      }
+    ))
     emitter.input('failure' => 'bad')
     expect(callback_executed).to eq(true)
   end
 
   it 'correctly batches multiple events' do
-    emitter = SnowplowTracker::Emitter.new('localhost', default_opts.merge(
-                                                          method: 'post', buffer_size: 3
-                                                        ))
+    emitter = SnowplowTracker::Emitter.new(endpoint: 'localhost', options: default_opts.merge(
+      method: 'post', buffer_size: 3
+    ))
     emitter.input('key1' => 'value1')
     emitter.input('key2' => 'value2')
     emitter.input('key3' => 'value3')
@@ -116,7 +116,7 @@ describe SnowplowTracker::AsyncEmitter, 'Synchronous flush' do
   let(:default_opts) { { logger: NULL_LOGGER } }
 
   it 'sends all events synchronously' do
-    emitter = SnowplowTracker::AsyncEmitter.new('localhost', default_opts.merge(buffer_size: 6))
+    emitter = SnowplowTracker::AsyncEmitter.new(endpoint: 'localhost', options: default_opts.merge(buffer_size: 6))
     emitter.input('key' => 'value')
     emitter.flush(false)
     param_hash = CGI.parse(emitter.get_last_querystring)

--- a/spec/unit/payload_spec.rb
+++ b/spec/unit/payload_spec.rb
@@ -31,7 +31,7 @@ describe SnowplowTracker::Payload, 'context' do
   end
 
   it 'adds a dictionary of key-value pairs to the context' do
-    @payload.add_dict(
+    @payload.add_hash(
       'p' => 'mob',
       'tna' => 'cf',
       'aid' => 'cd767ae'

--- a/spec/unit/tracker_spec.rb
+++ b/spec/unit/tracker_spec.rb
@@ -25,12 +25,12 @@ end
 
 describe SnowplowTracker::Tracker, 'configuration' do
   let(:emitter) do
-    SnowplowTracker::Emitter.new('d3rkrsqld9gmqf.cloudfront.net',
-                                 logger: NULL_LOGGER)
+    SnowplowTracker::Emitter.new(endpoint: 'd3rkrsqld9gmqf.cloudfront.net',
+                                 options: { logger: NULL_LOGGER })
   end
 
   before(:each) do
-    @t = SnowplowTracker::Tracker.new(emitter, nil, 'cloudfront', 'AF003', false)
+    @t = SnowplowTracker::Tracker.new(emitters: emitter, namespace: 'cloudfront', app_id: 'AF003', encode_base64: false)
   end
 
   it 'should initialise standard name-value pairs' do


### PR DESCRIPTION
This PR solves issue #134.

Use keyword arguments for all public API methods with more than two arguments.

The [Contracts](https://github.com/egonSchiele/contracts.ruby) type-checking gem allows for this with the `KeywordArgs` label. However, this only works with Ruby 3 in v0.17, and Ruby 2 in versions below 0.17. Therefore I added some conditional versioning to the gemspec.