### PR TITLE
Update supported platforms list

### DIFF
--- a/lib/snowplow-tracker/subject.rb
+++ b/lib/snowplow-tracker/subject.rb
@@ -20,7 +20,7 @@ module SnowplowTracker
     include Contracts
 
     DEFAULT_PLATFORM = 'srv'
-    SUPPORTED_PLATFORMS = %w[pc tv mob cnsl iot]
+    SUPPORTED_PLATFORMS = %w[web app pc tv mob cnsl iot srv]
 
     attr_reader :standard_nv_pairs
 

--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -257,7 +257,7 @@ describe SnowplowTracker::Tracker, 'Querystring construction' do
 
   it 'adds standard name-value pairs to the payload' do
     t = SnowplowTracker::Tracker.new(emitters: e, namespace: 'cf', app_id: 'angry-birds-android')
-    t.set_platform('mob')
+    t.set_platform('app')
     t.set_user_id('user12345')
     t.set_screen_resolution(width: 400, height: 200)
     t.set_viewport(width: 100, height: 80)
@@ -276,7 +276,7 @@ describe SnowplowTracker::Tracker, 'Querystring construction' do
       'aid' => 'angry-birds-android',
       'cd' => '24',
       'tz' => 'Europe London',
-      'p' => 'mob',
+      'p' => 'app',
       'fp' => '987654321',
       'tv' => SnowplowTracker::TRACKER_VERSION
     }


### PR DESCRIPTION
Add the missing platform values into the list of supported choices. Now it's possible to define an event as being on "web" or "app".

Solves issue #136 