### PR TITLE
Add methods for domain_session_id and domain_session_idx

### DIFF
--- a/lib/snowplow-tracker/subject.rb
+++ b/lib/snowplow-tracker/subject.rb
@@ -112,6 +112,24 @@ module SnowplowTracker
       self
     end
 
+    # Set the domain session ID
+    # Part of the public API
+    #
+    Contract String => Subject
+    def set_domain_session_id(sid)
+      @details['sid'] = sid
+      self
+    end
+
+    # Set the domain session index
+    # Part of the public API
+    #
+    Contract Num => Subject
+    def set_domain_session_idx(vid)
+      @details['vid'] = vid
+      self
+    end
+
     # Set the IP address field
     # Part of the public API
     #

--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -425,6 +425,8 @@ describe SnowplowTracker::Tracker, 'Querystring construction' do
     t.set_timezone('Europe London')
     t.set_lang('en')
     t.set_domain_user_id('aeb1691c5a0ee5a6')
+    t.set_domain_session_id('9c65e7f3-8e8e-470d-b243-910b5b300da0')
+    t.set_domain_session_idx(2)
     t.set_ip_address('255.255.255.255')
     t.set_useragent('Mozilla/5.0')
     t.set_network_user_id('ecdff4d0-9175-40ac-a8bb-325c49733607')
@@ -442,6 +444,8 @@ describe SnowplowTracker::Tracker, 'Querystring construction' do
       'tz' => 'Europe London',
       'p' => 'mob',
       'duid' => 'aeb1691c5a0ee5a6',
+      'sid' => '9c65e7f3-8e8e-470d-b243-910b5b300da0',
+      'vid' => '2',
       'ua' => 'Mozilla/5.0',
       'ip' => '255.255.255.255',
       'tnuid' => 'ecdff4d0-9175-40ac-a8bb-325c49733607',


### PR DESCRIPTION
Relating to this issue #106.

This allows the setting of session identifiers into the Subject. This should make it easier to match event data between the front and backend.