### PR TITLE
Strip empty contexts array from payload

### DIFF
--- a/lib/snowplow-tracker/tracker.rb
+++ b/lib/snowplow-tracker/tracker.rb
@@ -138,7 +138,7 @@ module SnowplowTracker
 
     Contract Payload, Maybe[CONTEXTS_INPUT], Timestamp, Maybe[Subject], Maybe[Page] => nil
     def finalise_payload(payload, context, tstamp, event_subject, page)
-      payload.add_json(build_context(context), @encode_base64, 'cx', 'co') unless context.nil?
+      payload.add_json(build_context(context), @encode_base64, 'cx', 'co') unless context.nil? || context.empty?
       payload.add_hash(page.details) unless page.nil?
 
       if event_subject.nil?

--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -52,6 +52,12 @@ describe SnowplowTracker::Tracker, 'Querystring construction' do
     expected_fields.each { |pair| expect(param_hash[pair[0]][0]).to eq(pair[1]) }
   end
 
+  it 'removes an empty context array' do
+    t.track_page_view(page_url: 'http://example.com', context: [])
+    param_hash = CGI.parse(e.get_last_querystring)
+    expect(param_hash).not_to have_key('cx')
+  end
+
   it 'tracks a page view with custom subject' do
     event_subject = SnowplowTracker::Subject.new
     event_subject.set_screen_resolution(width: 100, height: 400)


### PR DESCRIPTION
Relating to issue #104.

Empty context arrays got processed and ended up in the raw event, sending a few bytes unnecessarily. This stops that happening.