### PR TITLE
Remove Contracts dependency

### DIFF
--- a/lib/snowplow-tracker/emitters.rb
+++ b/lib/snowplow-tracker/emitters.rb
@@ -17,7 +17,6 @@
 require 'net/https'
 require 'set'
 require 'logger'
-require 'contracts'
 
 module SnowplowTracker
   # @see Emitter
@@ -61,30 +60,6 @@ module SnowplowTracker
   #   require 'logger'
   #   SnowplowTracker::LOGGER.level = Logger::DEBUG
   class Emitter
-    include Contracts
-
-    # Contract types
-
-    # @private
-    CONFIG_HASH = {
-      path: Maybe[String],
-      protocol: Maybe[Or['http', 'https']],
-      port: Maybe[Num],
-      method: Maybe[Or['get', 'post']],
-      buffer_size: Maybe[Num],
-      on_success: Maybe[Func[Num => Any]],
-      on_failure: Maybe[Func[Num, Hash => Any]],
-      thread_count: Maybe[Num],
-      logger: Maybe[Logger]
-    }
-
-    # @private
-    STRICT_CONFIG_HASH = And[CONFIG_HASH, ->(x) {
-                                            (x.class == Hash) && Set.new(x.keys).subset?(Set.new(CONFIG_HASH.keys))
-                                          }]
-
-    # @!group Public constants
-
     # Default Emitter settings
     DEFAULT_CONFIG = {
       protocol: 'http',
@@ -96,7 +71,6 @@ module SnowplowTracker
     # @private
     attr_reader :logger
 
-    Contract KeywordArgs[endpoint: String, options: Optional[STRICT_CONFIG_HASH]] => Any
     # Create a new Emitter instance. The endpoint is required.
     #
     # @example Initializing an Emitter with all the possible extra configuration.
@@ -153,7 +127,6 @@ module SnowplowTracker
       logger.info("#{self.class} initialized with endpoint #{@collector_uri}")
     end
 
-    Contract Hash => Num
     # Creates the `@buffer_size` variable during initialization. Unless
     # otherwise defined, it's 1 for Emitters using GET and 10 for Emitters using
     # POST requests.
@@ -164,7 +137,6 @@ module SnowplowTracker
       config[:method] == 'get' ? 1 : 10
     end
 
-    Contract Hash => String
     # Creates the `@path` variable during initialization. Allows a non-standard
     # path to be provided.
     # @private
@@ -174,9 +146,6 @@ module SnowplowTracker
       config[:method] == 'get' ? '/i' : '/com.snowplowanalytics.snowplow/tp2'
     end
 
-    # Build the collector URI from the configuration hash
-    #
-    Contract String, String, Maybe[Num], String => String
     # Creates the `@collector_uri` variable during initialization.
     # The default is "http://{endpoint}/i".
     # @private
@@ -186,7 +155,6 @@ module SnowplowTracker
       "#{protocol}://#{endpoint}#{port_string}#{path}"
     end
 
-    Contract Hash => nil
     # Add an event to the buffer and flush it if maximum size has been reached.
     # This method is not required for standard Ruby tracker usage. A {Tracker}
     # privately calls this method once the event payload is ready to send.
@@ -216,7 +184,6 @@ module SnowplowTracker
       nil
     end
 
-    Contract Bool => nil
     # Flush the Emitter, forcing it to send all the events in its
     # buffer, even if the buffer is not full. {Emitter} objects, unlike
     # {AsyncEmitter}s, can only `flush` synchronously. A {Tracker} can manually flush all
@@ -237,7 +204,6 @@ module SnowplowTracker
       nil
     end
 
-    Contract ArrayOf[Hash] => nil
     # Send all events in the buffer to the collector
     # @private
     def send_requests(events)
@@ -262,7 +228,6 @@ module SnowplowTracker
       nil
     end
 
-    Contract ArrayOf[Hash] => nil
     # Part of {#send_requests}.
     # @private
     def send_requests_with_post(events)
@@ -286,7 +251,6 @@ module SnowplowTracker
       nil
     end
 
-    Contract ArrayOf[Hash] => nil
     # Part of {#send_requests}.
     # @private
     def send_requests_with_get(events)
@@ -307,7 +271,6 @@ module SnowplowTracker
       nil
     end
 
-    Contract Hash => Bool
     # Part of {#send_requests_with_get}.
     # @private
     def process_get_event(event)
@@ -321,7 +284,6 @@ module SnowplowTracker
       get_succeeded
     end
 
-    Contract Hash => ->(x) { x.is_a? Net::HTTPResponse }
     # Part of {#process_get_event}. This sends a GET request.
     # @private
     def http_get(payload)
@@ -339,7 +301,6 @@ module SnowplowTracker
       response
     end
 
-    Contract Hash => ->(x) { x.is_a? Net::HTTPResponse }
     # Part of {#send_requests_with_post}. This sends a POST request.
     # @private
     def http_post(payload)
@@ -359,7 +320,6 @@ module SnowplowTracker
       response
     end
 
-    Contract String => Bool
     # Check if the response is good.
     # Only 2xx and 3xx status codes are considered successes.
     # @private
@@ -381,7 +341,6 @@ module SnowplowTracker
   # @see Emitter
   # @api public
   class AsyncEmitter < Emitter
-    Contract KeywordArgs[endpoint: String, options: Optional[STRICT_CONFIG_HASH]] => Any
     # Create a new AsyncEmitter object. The endpoint is required.
     #
     # @example Initializing an AsyncEmitter with all the possible extra configuration.

--- a/lib/snowplow-tracker/page.rb
+++ b/lib/snowplow-tracker/page.rb
@@ -14,8 +14,6 @@
 # License:: Apache License Version 2.0
 
 
-require 'contracts'
-
 module SnowplowTracker
   # If the Ruby tracker is incorporated into a website server, the events
   # tracked will describe user activity on specific webpages. Knowing on which
@@ -33,12 +31,9 @@ module SnowplowTracker
   # @note For {Tracker#track_page_view}, properties set in the Page object will
   #   override those properties given as arguments.
   class Page
-    include Contracts
-
     # @return [Hash] the stored page properties
     attr_reader :details
 
-    Contract KeywordArgs[page_url: Maybe[String], page_title: Maybe[String], referrer: Maybe[String]] => Any
     # Create a Page object for attaching page properties to events.
     #
     # Page properties will directly populate the event's `page_url`, `page_title` and `referrer` parameters.

--- a/lib/snowplow-tracker/payload.rb
+++ b/lib/snowplow-tracker/payload.rb
@@ -17,7 +17,6 @@
 require 'base64'
 require 'json'
 require 'net/http'
-require 'contracts'
 
 module SnowplowTracker
   # @private
@@ -26,28 +25,22 @@ module SnowplowTracker
   # hash. These properties form the raw event, after the completed hash is
   # given to the Emitter.
   class Payload
-    include Contracts
-
     attr_reader :data
 
-    Contract nil => Any
     def initialize
       @data = {}
     end
 
-    Contract String, Or[String, Bool, Num, nil] => Or[String, Bool, Num, nil]
     # Add a single name-value pair to @data.
     def add(name, value)
       @data[name] = value if (value != '') && !value.nil?
     end
 
-    Contract Hash => Hash
     # Add each name-value pair in a hash to @data.
     def add_hash(hash)
       hash.each { |key, value| add(key, value) }
     end
 
-    Contract Maybe[Hash], Bool, String, String => Maybe[String]
     # Stringify a JSON and add it to @data.
     #
     # In practice, the JSON provided will be a SelfDescribingJson. This method

--- a/lib/snowplow-tracker/subject.rb
+++ b/lib/snowplow-tracker/subject.rb
@@ -14,8 +14,6 @@
 # License:: Apache License Version 2.0
 
 
-require 'contracts'
-
 module SnowplowTracker
   # Subject objects store information about the user associated with the event,
   # such as their `user_id`, what type of device they used, or what size screen
@@ -87,8 +85,6 @@ module SnowplowTracker
   #   method chaining, e.g.
   #   `Subject.new.set_timezone('Europe/London').set_user_id('12345')`
   class Subject
-    include Contracts
-
     # @private
     DEFAULT_PLATFORM = 'srv'
 
@@ -113,13 +109,11 @@ module SnowplowTracker
     # @api public
     attr_reader :details
 
-    Contract None => Any
     # @api public
     def initialize
       @details = { 'p' => DEFAULT_PLATFORM }
     end
 
-    Contract String => Subject
     # Set the platform to one of the supported platform values.
     # @note Value is sent in the event as `p` (raw event) or `platform` (processed event).
     # @see Subject::SUPPORTED_PLATFORMS
@@ -133,7 +127,6 @@ module SnowplowTracker
       self
     end
 
-    Contract String => Subject
     # Set the unique business-defined user ID for a user.
     # @note Value is sent in the event as `uid` (raw event) or `user_id` (processed event).
     # For example, an email address.
@@ -152,7 +145,6 @@ module SnowplowTracker
       self
     end
 
-    Contract Num => Subject
     # Set a business-defined fingerprint for a user.
     # @note Value is sent in the event as `fp` (raw event) or `user_fingerprint` (processed event).
     # @param [Num] fingerprint a user fingerprint
@@ -163,7 +155,6 @@ module SnowplowTracker
       self
     end
 
-    Contract KeywordArgs[width: Num, height: Num] => Subject
     # Set the device screen resolution.
     # @note Value is sent in the event as `res` (raw event) or `dvce_screenheight` and `dvce_screenwidth` (processed event).
     # @param [Num] width the screen width, in pixels (must be a positive integer)
@@ -175,7 +166,6 @@ module SnowplowTracker
       self
     end
 
-    Contract KeywordArgs[width: Num, height: Num] => Subject
     # Set the dimensions of the current viewport.
     # @note Value is sent in the event as `vp` (raw event) or `br_viewwidth` and `br_viewheight` (processed event).
     # @param [Num] width the viewport width, in pixels (must be a positive integer)
@@ -187,7 +177,6 @@ module SnowplowTracker
       self
     end
 
-    Contract Num => Subject
     # Set the color depth of the device, in bits per pixel.
     # @note Value is sent in the event as `cd` (raw event) or `br_colordepth` (processed event).
     # @param [Num] depth the colour depth
@@ -198,7 +187,6 @@ module SnowplowTracker
       self
     end
 
-    Contract String => Subject
     # Set the timezone to that of the user's OS.
     # @note Value is sent in the event as `tz` (raw event) or `os_timezone` (processed event).
     # @example
@@ -211,7 +199,6 @@ module SnowplowTracker
       self
     end
 
-    Contract String => Subject
     # Set the language.
     # @note Value is sent in the event as `lang` (raw event) or `br_lang` (processed event).
     # @example Setting the language to Spanish
@@ -224,7 +211,6 @@ module SnowplowTracker
       self
     end
 
-    Contract String => Subject
     # Set the domain user ID.
     # @note Value is sent in the event as `duid` (raw event) or `domain_userid` (processed event).
     # @see Subject#set_network_user_id
@@ -260,7 +246,6 @@ module SnowplowTracker
       self
     end
 
-    Contract String => Subject
     # Set the domain session ID.
     # @note Value is sent in the event as `sid` (raw event) or `domain_sessionid` (processed event).
     # @see Subject#set_network_user_id
@@ -283,7 +268,6 @@ module SnowplowTracker
       self
     end
 
-    Contract Num => Subject
     # Set the domain session index.
     # @note Value is sent in the event as `vid` (raw event) or `domain_sessionidx` (processed event).
     # @see Subject#set_network_user_id
@@ -307,7 +291,6 @@ module SnowplowTracker
       self
     end
 
-    Contract String => Subject
     # Set the user's IP address.
     # @note Value is sent in the event as `ip` (raw event) or `user_ipaddress` (processed event).
     # @param [String] ip the IP address
@@ -318,7 +301,6 @@ module SnowplowTracker
       self
     end
 
-    Contract String => Subject
     # Set the browser user agent.
     # @note Value is sent in the event as `ua` (raw event) or `useragent` (processed event).
     # @example
@@ -331,7 +313,6 @@ module SnowplowTracker
       self
     end
 
-    Contract String => Subject
     # Set the network user ID.
     # @note Value is sent in the event as `tnuid` (raw event) and `network_userid` (processed event).
     # @see Subject#set_domain_user_id

--- a/lib/snowplow-tracker/timestamp.rb
+++ b/lib/snowplow-tracker/timestamp.rb
@@ -58,20 +58,11 @@ module SnowplowTracker
   #   the Snowplow Tracker Protocol
   # @api public
   class Timestamp
-    include Contracts
-
     # @private
     attr_reader :type
 
     # @private
     attr_reader :value
-
-    # @private
-    # Contract type
-    TIMESTAMP = ->(x) {
-      return false unless x.is_a? Integer
-      x.to_s.length == 13
-    }
 
     # @private
     def initialize(type, value)
@@ -92,7 +83,6 @@ module SnowplowTracker
   # it is, namely `ttm`. This raw event `ttm` field will be processed into
   # `true_tstamp` in the completed event.
   class TrueTimestamp < Timestamp
-    Contract TIMESTAMP => Any
     # @param [Num] value timestamp in milliseconds since the Unix epoch
     # @example
     #   TrueTimestamp.new(1633596346786)
@@ -107,7 +97,6 @@ module SnowplowTracker
   # it is, namely `dtm`. This raw event `dtm` field will be processed into
   # `dvce_created_tstamp` in the completed event.
   class DeviceTimestamp < Timestamp
-    Contract TIMESTAMP => Any
     # @param [Num] value timestamp in milliseconds since the Unix epoch
     # @example
     #   DeviceTimestamp.new(1633596346786)

--- a/lib/snowplow-tracker/version.rb
+++ b/lib/snowplow-tracker/version.rb
@@ -24,13 +24,6 @@
 # see an example of how to incorporate the Snowplow Ruby tracker in Ruby on
 # Rails app.
 #
-# # Type checking
-#
-# This gem uses the [Contracts](https://github.com/egonSchiele/contracts.ruby)
-# gem for typechecking. This cannot be disabled. The {Tracker} `track_x_event`
-# methods expect arguments of a certain type. If a check fails, a runtime error
-# is thrown.
-#
 # @see https://github.com/snowplow/snowplow-ruby-tracker
 #   Ruby tracker on Github
 # @see https://github.com/snowplow-incubator/snowplow-ruby-tracker-examples
@@ -41,7 +34,7 @@
 # @api public
 module SnowplowTracker
   # The version of Ruby Snowplow tracker you are using
-  VERSION = '0.7.0'
+  VERSION = '0.8.0-alpha.0'
 
   # All events from this tracker will have this string
   TRACKER_VERSION = "rb-#{VERSION}"

--- a/snowplow-tracker.gemspec
+++ b/snowplow-tracker.gemspec
@@ -32,11 +32,6 @@ Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.required_ruby_version = '>= 2.1'
 
-  if RUBY_VERSION >= '3.0.0'
-    s.add_runtime_dependency 'contracts', '~> 0.17'
-  else
-    s.add_runtime_dependency 'contracts', '~> 0.7', '< 0.17'
-  end
   s.add_development_dependency 'rspec', '~> 3.10'
   s.add_development_dependency 'webmock', '~> 3.14'
 end


### PR DESCRIPTION
For issues #155 and #154.

Removes the Contracts gem which is causing problems with Ruby 3 in conjunction with the keyword arguments added in tracker version 0.7.0.