### PR TITLE
Add Snyk monitoring GitHub Action (close #157)

### DIFF
--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -1,0 +1,26 @@
+name: Snyk
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  security:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 3.0
+        bundler-cache: true # runs ‘bundle install’ and caches installed gems automatically
+      
+    - name: Run Snyk to check for vulnerabilities
+      uses: snyk/actions/ruby@master
+      with:
+        command: monitor
+        args: --project-name=snowplow-ruby-tracker
+      env:
+        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ limitations under the License.
 [license-image]: https://img.shields.io/badge/license-Apache--2-blue.svg?style=flat
 [license]: https://www.apache.org/licenses/LICENSE-2.0
 [gh-actions]: https://github.com/snowplow/snowplow-ruby-tracker/actions
-[gh-actions-image]: https://github.com/snowplow/snowplow-ruby-tracker/workflows/test.yml/badge.svg
+[gh-actions-image]: https://github.com/snowplow/snowplow-ruby-tracker/workflows/Test/badge.svg
 [tracker-classification]: https://docs.snowplowanalytics.com/docs/collecting-data/collecting-from-own-applications/tracker-maintenance-classification/
 [early-release]: https://img.shields.io/static/v1?style=flat&label=Snowplow&message=Early%20Release&color=014477&labelColor=9ba0aa&logo=data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAMAAAAoLQ9TAAAAeFBMVEVMaXGXANeYANeXANZbAJmXANeUANSQAM+XANeMAMpaAJhZAJeZANiXANaXANaOAM2WANVnAKWXANZ9ALtmAKVaAJmXANZaAJlXAJZdAJxaAJlZAJdbAJlbAJmQAM+UANKZANhhAJ+EAL+BAL9oAKZnAKVjAKF1ALNBd8J1AAAAKHRSTlMAa1hWXyteBTQJIEwRgUh2JjJon21wcBgNfmc+JlOBQjwezWF2l5dXzkW3/wAAAHpJREFUeNokhQOCA1EAxTL85hi7dXv/E5YPCYBq5DeN4pcqV1XbtW/xTVMIMAZE0cBHEaZhBmIQwCFofeprPUHqjmD/+7peztd62dWQRkvrQayXkn01f/gWp2CrxfjY7rcZ5V7DEMDQgmEozFpZqLUYDsNwOqbnMLwPAJEwCopZxKttAAAAAElFTkSuQmCC
 


### PR DESCRIPTION
Added a Snyk monitoring workflow. Results are here: https://app.snyk.io/org/data-value/project/07e507b8-baff-4560-b977-c6bc81540142

I ran a workflow on `push` to test: https://github.com/snowplow/snowplow-ruby-tracker/actions/runs/1382880775

However, this PR now only runs on merge to `master` so we only update our dependency graphs on release new software to `master` (snyk continuously scans the last dependency graph).