### PR TITLE
Fix minor mistakes in YARD API docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,13 +9,11 @@
 
 ## Overview
 
-Add analytics to your Ruby and Rails apps and gems with the **[Snowplow][snowplow]** event tracker for **[Ruby][ruby]**.
+Add analytics to your **[Ruby][ruby]** and **[Ruby on Rails][rails]** apps and **[gems][rubygems]** with the **[Snowplow][snowplow]** event tracker for **[Ruby][ruby]**.
 
 Snowplow is a scalable open-source platform for rich, high quality, low-latency data collection. It is designed to collect high quality, complete behavioral data for enterprise business.
 
 **To find out more, please check out the [Snowplow website][snowplow] and our [documentation][docs].**
-
-With this tracker you can collect event data from your **[Ruby][ruby]** applications, **[Ruby on Rails][rails]** web applications and **[Ruby gems][rubygems]**.
 
 ## Quickstart
 
@@ -47,9 +45,14 @@ The `-v` flag for `docker run` creates a bind mount for the project directory. T
 
 Alternatively, test directly by installing Ruby 2.1+ and [Bundler][bundler]. Then run:
 
-```
+```bash
 bundle install
 rspec
+```
+
+To generate documentation using YARD, make sure the YARD and redcarpet gems are installed locally. Then run:
+```bash
+yard doc
 ```
 
 ## Contributing

--- a/lib/snowplow-tracker/page.rb
+++ b/lib/snowplow-tracker/page.rb
@@ -39,7 +39,7 @@ module SnowplowTracker
     # Page properties will directly populate the event's `page_url`, `page_title` and `referrer` parameters.
     #
     # @example Creating a Page
-    #   Page.new(page_url: 'http://www.example.com/second-page',
+    #   SnowplowTracker::Page.new(page_url: 'http://www.example.com/second-page',
     #            page_title: 'Example title',
     #            referrer: 'http://www.example.com/first-page')
     #

--- a/lib/snowplow-tracker/self_describing_json.rb
+++ b/lib/snowplow-tracker/self_describing_json.rb
@@ -77,7 +77,7 @@ module SnowplowTracker
   #   # Creating the SelfDescribingJson
   #   schema_name = "iglu:com.snowplowanalytics/ad_click/jsonschema/1-0-0"
   #   event_data = { bannerId: "4acd518feb82" }
-  #   SelfDescribingJson.new(schema_name, event_data)
+  #   SnowplowTracker::SelfDescribingJson.new(schema_name, event_data)
   #
   #   # The self-describing JSON that will be sent (stringified) with the event
   #   {

--- a/lib/snowplow-tracker/subject.rb
+++ b/lib/snowplow-tracker/subject.rb
@@ -66,7 +66,7 @@ module SnowplowTracker
   #
   # Since many of the Subject parameters describe the user, different Subject
   # properties may often be desired for each event, if there are multiple users.
-  # This can be achieved in one of two ways:
+  # This can be achieved in one of three ways:
   #
   # 1. the properties of the Tracker-associated Subject can be overriden by the
   #    properties of an event-specific Subject. A Subject can be added to any
@@ -74,16 +74,21 @@ module SnowplowTracker
   #    set the platform for the event Subject if you're not using `srv`.
   # 2. the Tracker-associated Subject can be swapped for another Subject, using
   #    the Tracker method {Tracker#set_subject}.
+  # 3. the properties of the Tracker-associated Subject can be changed before
+  #    every `#track_x_event`, by calling the Subject methods via the Tracker.
   #
   # @see Tracker#set_subject
   # @see
   #   https://docs.snowplowanalytics.com/docs/collecting-data/collecting-from-own-applications/snowplow-tracker-protocol
   #   the Snowplow Tracker Protocol
+  # @see
+  #   https://docs.snowplowanalytics.com/docs/collecting-data/collecting-from-own-applications/ruby-tracker/enriching-your-events/
+  #   the Snowplow docs page about adding context and other extra data to events
   # @api public
   #
   # @note All the Subject instance methods return the Subject object, allowing
   #   method chaining, e.g.
-  #   `Subject.new.set_timezone('Europe/London').set_user_id('12345')`
+  #   `SnowplowTracker::Subject.new.set_timezone('Europe/London').set_user_id('12345')`
   class Subject
     # @private
     DEFAULT_PLATFORM = 'srv'
@@ -104,7 +109,7 @@ module SnowplowTracker
 
     # Access the Subject parameters
     # @example
-    #   Subject.new.set_user_id('12345').details
+    #   SnowplowTracker::Subject.new.set_user_id('12345').details
     #   => {"p"=>"srv", "uid"=>"12345"}
     # @api public
     attr_reader :details
@@ -118,6 +123,8 @@ module SnowplowTracker
     # @note Value is sent in the event as `p` (raw event) or `platform` (processed event).
     # @see Subject::SUPPORTED_PLATFORMS
     # @param [String] platform a valid platform choice
+    # @example
+    #   subject.set_platform('app')
     # @return self
     # @api public
     def set_platform(platform)
@@ -149,6 +156,8 @@ module SnowplowTracker
     # @note Value is sent in the event as `fp` (raw event) or `user_fingerprint` (processed event).
     # @param [Num] fingerprint a user fingerprint
     # @return self
+    # @example
+    #   subject.set_fingerprint(4048966212)
     # @api public
     def set_fingerprint(fingerprint)
       @details['fp'] = fingerprint
@@ -157,9 +166,11 @@ module SnowplowTracker
 
     # Set the device screen resolution.
     # @note Value is sent in the event as `res` (raw event) or `dvce_screenheight` and `dvce_screenwidth` (processed event).
-    # @param [Num] width the screen width, in pixels (must be a positive integer)
-    # @param [Num] height the screen height, in pixels (must be a positive integer)
+    # @param [Integer] width the screen width, in pixels (must be a positive integer)
+    # @param [Integer] height the screen height, in pixels (must be a positive integer)
     # @return self
+    # @example
+    #   subject.set_screen_resolution(width: 2880, height: 1800)
     # @api public
     def set_screen_resolution(width:, height:)
       @details['res'] = "#{width}x#{height}"
@@ -168,18 +179,22 @@ module SnowplowTracker
 
     # Set the dimensions of the current viewport.
     # @note Value is sent in the event as `vp` (raw event) or `br_viewwidth` and `br_viewheight` (processed event).
-    # @param [Num] width the viewport width, in pixels (must be a positive integer)
-    # @param [Num] height the viewport height, in pixels (must be a positive integer)
+    # @param [Integer] width the viewport width, in pixels (must be a positive integer)
+    # @param [Integer] height the viewport height, in pixels (must be a positive integer)
     # @return self
+    # @example
+    #   subject.set_viewport(width: 1440, height: 762)
     # @api public
     def set_viewport(width:, height:)
       @details['vp'] = "#{width}x#{height}"
       self
     end
 
-    # Set the color depth of the device, in bits per pixel.
+    # Set the color depth of the browser, in bits per pixel.
     # @note Value is sent in the event as `cd` (raw event) or `br_colordepth` (processed event).
     # @param [Num] depth the colour depth
+    # @example
+    #   subject.set_color_depth(24)
     # @return self
     # @api public
     def set_color_depth(depth)
@@ -295,6 +310,8 @@ module SnowplowTracker
     # @note Value is sent in the event as `ip` (raw event) or `user_ipaddress` (processed event).
     # @param [String] ip the IP address
     # @return self
+    # @example
+    #   subject.set_ip_address('37.157.33.178')
     # @api public
     def set_ip_address(ip)
       @details['ip'] = ip

--- a/lib/snowplow-tracker/timestamp.rb
+++ b/lib/snowplow-tracker/timestamp.rb
@@ -38,24 +38,31 @@ module SnowplowTracker
   #    DeviceTimestamp by the Tracker, and will still be recorded as `dtm` in
   #    the event.
   # 2. Manually create a DeviceTimestamp (e.g.
-  #    `DeviceTimestamp.new(1633596554978)`), and provide this to the
+  #    `SnowplowTracker::DeviceTimestamp.new(1633596554978)`), and provide this to the
   #    `#track_x_event` method. This will still be recorded as `dtm` in the
   #    event.
   # 3. Provide a TrueTimestamp object to the `track_x_event` method (e.g.
-  #    `TrueTimestamp.new(1633596554978)`). This will result in a `ttm` field in
+  #    `SnowplowTracker::TrueTimestamp.new(1633596554978)`). This will result in a `ttm` field in
   #    the event.
   #
   # The timestamps that are added to the event once it has been emitted are not
   # the responsibility of this class. The collector receives the event and adds a
   # `collector_tstamp`. A later part of the pipeline adds the `etl_tstamp` when
-  # the event enrichment has finished. A `derived_tstamp` is also calculated and
-  # added to the event, which represents how long it took the event to be
-  # processed. This is calculated by `collector_tstamp - (dvce_sent_tstamp -
-  # dvce_created_tstamp)`.
+  # the event enrichment has finished.
+  #
+  # When DeviceTimestamp is used, a `derived_tstamp` is also calculated and
+  # added to the event. This timestamp attempts to take latency and possible
+  # inaccuracy of the device clock into account. It is calculated by
+  # `collector_tstamp - (dvce_sent_tstamp - dvce_created_tstamp)`. When
+  # TrueTimestamp is used, the `derived_stamp` will be the same as
+  # `true_tstamp`.
   #
   # @see
   #   https://docs.snowplowanalytics.com/docs/collecting-data/collecting-from-own-applications/snowplow-tracker-protocol
   #   the Snowplow Tracker Protocol
+  # @see
+  #   https://discourse.snowplowanalytics.com/t/which-timestamp-is-the-best-to-see-when-an-event-occurred/538
+  #   A Discourse forums post explaining timestamps
   # @api public
   class Timestamp
     # @private
@@ -85,7 +92,7 @@ module SnowplowTracker
   class TrueTimestamp < Timestamp
     # @param [Num] value timestamp in milliseconds since the Unix epoch
     # @example
-    #   TrueTimestamp.new(1633596346786)
+    #   SnowplowTracker::TrueTimestamp.new(1633596346786)
     def initialize(value)
       super 'ttm', value
     end
@@ -99,7 +106,7 @@ module SnowplowTracker
   class DeviceTimestamp < Timestamp
     # @param [Num] value timestamp in milliseconds since the Unix epoch
     # @example
-    #   DeviceTimestamp.new(1633596346786)
+    #   SnowplowTracker::DeviceTimestamp.new(1633596346786)
     def initialize(value)
       super 'dtm', value
     end

--- a/lib/snowplow-tracker/tracker.rb
+++ b/lib/snowplow-tracker/tracker.rb
@@ -117,6 +117,12 @@ module SnowplowTracker
   #   https://docs.snowplowanalytics.com/docs/collecting-data/collecting-from-own-applications/snowplow-tracker-protocol
   #   the Snowplow Tracker Protocol
   # @see
+  #   https://docs.snowplowanalytics.com/docs/collecting-data/collecting-from-own-applications/ruby-tracker/tracking-events/
+  #   the Snowplow docs page about tracking events
+  # @see
+  #   https://docs.snowplowanalytics.com/docs/collecting-data/collecting-from-own-applications/ruby-tracker/enriching-your-events/
+  #   the Snowplow docs page about adding context and other extra data to events
+  # @see
   #   https://docs.snowplowanalytics.com/docs/understanding-tracking-design/introduction-to-tracking-design/
   #   introduction to Snowplow tracking design
   # @api public
@@ -147,14 +153,18 @@ module SnowplowTracker
     # @param app_id [String] the app ID
     # @param encode_base64 [Bool] whether JSONs will be base64-encoded or not
     # @example Initializing a Tracker with all possible options
-    #   Tracker.new(
-    #               emitters: Emitter.new('collector.example.com'),
-    #               subject: Subject.new,
+    #   SnowplowTracker::Tracker.new(
+    #               emitters: SnowplowTracker::Emitter.new(endpoint: 'collector.example.com'),
+    #               subject: SnowplowTracker::Subject.new,
     #               namespace: 'tracker_no_encode',
     #               app_id: 'rails_main',
     #               encode_base64: false
     #              )
     # @api public
+    #
+    # @note All the Tracker instance methods return the Tracker object, allowing
+    #   method chaining, e.g.
+    #   `SnowplowTracker::Tracker.new.set_user_id('12345').track_page_view(page_url: 'www.example.com`
     def initialize(emitters:, subject: nil, namespace: nil, app_id: nil, encode_base64: DEFAULT_ENCODE_BASE64)
       @emitters = Array(emitters)
       @subject = if subject.nil?
@@ -270,6 +280,10 @@ module SnowplowTracker
     end
 
     # Track a visit to a page.
+    # @example
+    #   SnowplowTracker::Tracker.new.track_page_view(page_url: 'www.example.com',
+    #                                                page_title: 'example',
+    #                                                referrer: 'www.referrer.com')
     #
     # @param page_url [String] the URL of the page
     # @param page_title [String] the page title
@@ -445,6 +459,15 @@ module SnowplowTracker
     # For fully customizable event tracking, we recommend you use
     # self-describing events.
     #
+    # @example
+    #   SnowplowTracker::Tracker.new.track_struct_event(
+    #     category: 'shop',
+    #     action: 'add-to-basket',
+    #     property: 'pcs',
+    #     value: 2
+    #   )
+    #
+    #
     # @see #track_self_describing_event
     #
     # @param category [String] the event category
@@ -486,6 +509,11 @@ module SnowplowTracker
     # "iglu:com.snowplowanalytics.snowplow/screen_view/jsonschema/1-0-0", and
     # the data field will contain the name and/or ID.
     #
+    # @example
+    #   SnowplowTracker::Tracker.new.track_screen_view(name: 'HUD > Save Game',
+    #                                                  id: 'screen23')
+    #
+    #
     # @see #track_page_view
     # @see #track_self_describing_event
     #
@@ -517,6 +545,20 @@ module SnowplowTracker
     #
     # This method creates an `unstruct` event type. It is actually an alias for
     # {#track_unstruct_event}, which is depreciated due to its unhelpful name.
+    #
+    # @example
+    #   self_desc_json = SnowplowTracker::SelfDescribingJson.new(
+    #     "iglu:com.example_company/save_game/jsonschema/1-0-2",
+    #     {
+    #       "saveId" => "4321",
+    #       "level" => 23,
+    #       "difficultyLevel" => "HARD",
+    #       "dlContent" => true
+    #     }
+    #   )
+    #
+    #   SnowplowTracker::Tracker.new.track_self_describing_event(event_json: self_desc_json)
+    #
     #
     # @param event_json [SelfDescribingJson] a SelfDescribingJson object
     # @param context [Array<SelfDescribingJson>] an array of SelfDescribingJson objects


### PR DESCRIPTION
For issue #153.

A couple of mistakes in the code examples: a missing keyword argument (old API), and the module name (`SnowplowTracker::`) was missing throughout.