### PR TITLE
Remove unused line in GH deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -86,4 +86,3 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./docs


### PR DESCRIPTION
For issue #152.

Deleted the line `publish_dir: ./docs`, because the YARD documentation isn't actually built in a `docs` folder. The GH Pages build seems to be working fine anyway via repo configuration.