### PR TITLE
Fix publish directory for GitHub Pages (close #162)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -86,3 +86,4 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs


### PR DESCRIPTION
- I added a temporary commit to test and just deploy the documentation (on this branch): https://github.com/snowplow/snowplow-ruby-tracker/commit/057f1fe9c7255702c1ebcf084caeb4b491c82988
- This triggered the following action: https://github.com/snowplow/snowplow-ruby-tracker/actions/runs/1400431843
- Which fixed the documentation: https://snowplow.github.io/snowplow-ruby-tracker/

This should just need merging to master. No need to tag or anything.

The reason we need this line is that I think we misunderstood the `publish_dir` option. This is the directory that the documentation has been published into (by YARD), not where it will do the publishing (thats destination_dir). Deploying into the root of `gh_pages` is fine so we don't need to set `destination_dir`, just the `publish_dir` for where YARD puts its docs.